### PR TITLE
Use explicit VP acl setting seperate to batching

### DIFF
--- a/acl-batch/main.tf
+++ b/acl-batch/main.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 resource "kafka_acl" "kafka_acl" {
-  for_each                     = setunion(local.ids, toset([for id in var.explicit_ids : tostring(id)]))
+  for_each                     = local.ids
   acl_permission_type          = var.acl_permission_type
   acl_principal                = "${var.acl_principal_prefix}${each.value}${var.acl_principal_suffix}"
   acl_host                     = var.acl_host

--- a/acl-batch/variables.tf
+++ b/acl-batch/variables.tf
@@ -95,9 +95,3 @@ variable "excluded_ids" {
   description = "Do not create ACLs for ids passed into this list"
   default     = []
 }
-
-variable "explicit_ids" {
-  type        = list(number)
-  description = "Include these IDs regardless of bulk iteration"
-  default     = []
-}

--- a/main.tf
+++ b/main.tf
@@ -18,5 +18,15 @@ module "acl_batch" {
   resource_pattern_type_filter = var.resource_pattern_type_filter
   resource_type                = var.resource_type
   excluded_ids                 = var.excluded_ids
-  explicit_ids                 = var.explicit_ids
+}
+
+resource "kafka_acl" "kafka_acl" {
+  for_each                     = toset([for id in var.explicit_ids : tostring(id)])
+  acl_permission_type          = var.acl_permission_type
+  acl_principal                = "${var.acl_principal_prefix}${each.value}${var.acl_principal_suffix}"
+  acl_host                     = var.acl_host
+  acl_operation                = var.acl_operation
+  resource_type                = var.resource_type
+  resource_pattern_type_filter = var.resource_pattern_type_filter
+  resource_name                = var.resource_name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,7 @@ variable "max_acl" {
     condition     = var.max_acl >= 0
     error_message = "Max ACL must be >= 0."
   }
+  default = 0
 }
 
 variable "min_acl" {


### PR DESCRIPTION
For our dev Kafka cluster, we want to render explicit ACLs instead of batch create thousands like in staging and production.